### PR TITLE
Add ORDER BY to nest data query

### DIFF
--- a/resources/utils/nest-get-json.php
+++ b/resources/utils/nest-get-json.php
@@ -16,7 +16,7 @@ case 'current':
 	$cutoff->sub(new DateInterval('P1M'));
 	$cutoff_ = $cutoff->format('Y-m-d');
 
-	$sql = "SELECT UNIX_TIMESTAMP(log_datetime) as timestamp, outside_temp, outside_humidity, away_status, leaf_status, current_temp, current_humidity, low_target_temp, high_target_temp, target_humidity, heat_on, humidifier_on, ac_on, fan_on, battery_level, is_online FROM nest WHERE log_datetime >= '$cutoff_'";
+	$sql = "SELECT UNIX_TIMESTAMP(log_datetime) as timestamp, outside_temp, outside_humidity, away_status, leaf_status, current_temp, current_humidity, low_target_temp, high_target_temp, target_humidity, heat_on, humidifier_on, ac_on, fan_on, battery_level, is_online FROM nest WHERE log_datetime >= '$cutoff_' ORDER BY log_datetime";
 	break;
 
 case 'daily':


### PR DESCRIPTION
Have the SQL query from the 'nest' table return data sorted by date/time to ensure that the graph renders correctly if date entries are out of order in the SQL database (can occur if entries are manually removed due to bad data received from one of the APIs.)

**Before:**

![screen shot 2015-06-26 at 7 55 14 am](https://cloud.githubusercontent.com/assets/484106/8376795/0a5fb334-1bd9-11e5-8667-6ec678d49b02.png)

**After:**

![screen shot 2015-06-26 at 7 57 26 am](https://cloud.githubusercontent.com/assets/484106/8376807/1c94445c-1bd9-11e5-9a1e-1acf85989169.png)
